### PR TITLE
Add Laravel 11 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/telegram-bot-sdk/addon-manager",
   "require": {
     "php": ">=8.1",
-    "illuminate/support": "^10",
+    "illuminate/support": "^10.0 || ^11.0",
     "thecodingmachine/discovery": "^1.2"
   },
   "require-dev": {


### PR DESCRIPTION
Hey there! 

Tell me, am i doing something wrong?

I can't get sdk 4 to install in a laravel project at the moment - it seems the "add-on manager" composer requirements are blocking things!

I think this should fix it.