### PR TITLE
Laravel 11 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/telegram-bot-sdk/addon-manager",
   "require": {
     "php": ">=8.1",
-    "illuminate/support": "^10",
+    "illuminate/support": "^10 || ^11",
     "thecodingmachine/discovery": "^1.2"
   },
   "require-dev": {


### PR DESCRIPTION
Have checked. 

With this change it is now possible to install the package on a new laravel 11 project.

The failing tests are due to a composer dependency on root package - but don't actually affect/matter in this case.


https://getcomposer.org/doc/articles/troubleshooting.md#dependencies-on-the-root-package

(This project is not the root package but it tries to install the root package `telegram-bot-sdk/telegram-bot-sdk` which requires this package and you get this circle hell going on). 